### PR TITLE
Changes to install in Mac

### DIFF
--- a/osgconv/osgconv.rb
+++ b/osgconv/osgconv.rb
@@ -119,7 +119,11 @@ def exportToOSG(selectionOnly, extension)
 	end
 
 	# Tell OSG where it can find its plugins
-	ENV['OSG_LIBRARY_PATH'] = File.dirname(osgviewerbin)
+	if RUBY_PLATFORM=~/darwin/
+		ENV['OSG_LIBRARY_PATH'] = File.dirname(osgviewerbin)+'/vendor/lib/osgPlugins-3.0.1'
+	else
+		ENV['OSG_LIBRARY_PATH'] = File.dirname(osgviewerbin)
+	end
 
 	# Change to output directory
 	outdir = File.dirname(outputFn)


### PR DESCRIPTION
I don't actually expect this branch to be merged, but it is only to explain what I'm currently doing to be able to generate a Mac installer:
1. Change executable extension according to platform
2. Changing OSG_LIBRARY_PATH to `/vendor/lib/osgPlugins-3.0.1`

I actually don't put the `osgconv` and `osgviewer` executables in `/osgconv`, but instead simlinks to the real files that are in `vendor/bin`.
